### PR TITLE
feat: support bbox origin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ interface ViewerConfig {
   highlightsConfig?: {
     enableMultilineHover?: boolean;
   };
+
+  // Coordinate origin for incoming bbox values
+  // Default: 'bottom-right'
+  bboxOrigin?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 }
 ```
 

--- a/example/src/components/SimpleExample.tsx
+++ b/example/src/components/SimpleExample.tsx
@@ -1,4 +1,10 @@
-import { HighlightStyle, InputHighlightData, PDFHighlightViewer, ZoomMode } from '../../../src';
+import {
+  BBoxOrigin,
+  HighlightStyle,
+  InputHighlightData,
+  PDFHighlightViewer,
+  ZoomMode,
+} from '../../../src';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ButtonVariant, DialButton, DialDropdown } from '@epam/ai-dial-ui-kit';
 import '@epam/ai-dial-ui-kit/styles.css';
@@ -75,6 +81,7 @@ export const SimpleExample: React.FC = () => {
   const [enableVirtualScrolling, setEnableVirtualScrolling] = useState(false);
   const [enableMultilineHover, setEnableMultilineHover] = useState(false);
   const [performanceMode, setPerformanceMode] = useState(false);
+  const [bboxOrigin, setBBoxOrigin] = useState<BBoxOrigin>('top-left');
 
   // Debug state (from events)
   const [totalPages, setTotalPages] = useState<number | null>(null);
@@ -119,8 +126,9 @@ export const SimpleExample: React.FC = () => {
       enableVirtualScrolling,
       enableMultilineHover,
       performanceMode,
+      bboxOrigin,
     });
-  }, [enableMultilineHover, enableVirtualScrolling, performanceMode, pushEvent]);
+  }, [bboxOrigin, enableMultilineHover, enableVirtualScrolling, performanceMode, pushEvent]);
 
   const goTo = useCallback((id: string) => viewerRef.current?.goToHighlight(id), []);
 
@@ -263,6 +271,21 @@ export const SimpleExample: React.FC = () => {
     pushEvent('ui.jumpToPage3Coord', { page: 3, x: 0, y: 10 });
   }, [pushEvent]);
 
+  const onBBoxOriginChange = useCallback(
+    (nextOrigin: BBoxOrigin) => {
+      setBBoxOrigin(nextOrigin);
+
+      const viewer = viewerRef.current as any;
+      if (!viewer) return;
+
+      viewer.options = { ...(viewer.options ?? {}), bboxOrigin: nextOrigin };
+      viewer.loadHighlights(highlights);
+
+      pushEvent('ui.bboxOriginChanged', { bboxOrigin: nextOrigin, applied: true });
+    },
+    [highlights, pushEvent]
+  );
+
   useEffect(() => {
     if (!containerRef.current) return;
 
@@ -277,6 +300,7 @@ export const SimpleExample: React.FC = () => {
           enableTextSelection: true,
           enableVirtualScrolling,
           performanceMode,
+          bboxOrigin,
           highlightsConfig: {
             enableMultilineHover,
           },
@@ -649,6 +673,35 @@ export const SimpleExample: React.FC = () => {
             performance mode
           </label>
 
+          <label style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+            bbox origin
+            <select
+              value={bboxOrigin}
+              onChange={(e) => onBBoxOriginChange(e.target.value as BBoxOrigin)}
+              style={{
+                background: 'rgba(255,255,255,0.08)',
+                color: '#ffffff',
+                border: '1px solid rgba(255,255,255,0.25)',
+                borderRadius: 6,
+                padding: '4px 8px',
+                height: 30,
+              }}
+            >
+              <option value="bottom-right" style={{ background: '#23252a', color: '#ffffff' }}>
+                bottom-right
+              </option>
+              <option value="bottom-left" style={{ background: '#23252a', color: '#ffffff' }}>
+                bottom-left
+              </option>
+              <option value="top-right" style={{ background: '#23252a', color: '#ffffff' }}>
+                top-right
+              </option>
+              <option value="top-left" style={{ background: '#23252a', color: '#ffffff' }}>
+                top-left
+              </option>
+            </select>
+          </label>
+
           <div style={{ fontFamily: 'monospace', fontSize: 12, opacity: 0.8 }}>
             page: <b>{currentPage}</b>
             {totalPages ? (
@@ -668,7 +721,7 @@ export const SimpleExample: React.FC = () => {
         </div>
 
         <div style={{ fontSize: 12, opacity: 0.75, marginTop: 4 }}>
-          Note: changing checkboxes requires <b>Reinit</b> to apply.
+          Note: bbox origin applies immediately; other options require <b>Reinit</b>.
         </div>
       </div>
 

--- a/src/PDFHighlightViewer.ts
+++ b/src/PDFHighlightViewer.ts
@@ -1,6 +1,9 @@
 import { PDFHighlightViewer as IPDFHighlightViewer } from './api';
 import {
   ViewerOptions,
+  BBoxOrigin,
+  BBox,
+  BoundingBox,
   TextRange,
   SelectionWithMetadata,
   PerformanceMetrics,
@@ -73,6 +76,7 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
       interactionMode: 'hybrid',
       performanceMode: false,
       accessibility: true,
+      bboxOrigin: 'bottom-right',
     };
     this.pdfEngine = new PDFEngine(this.options);
     this.viewportManager = new ViewportManager(
@@ -388,23 +392,18 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
     const cached = this.pageDimensions.get(pageNumber);
     if (cached) return cached;
 
-    try {
-      // Get PDF page and its viewport at current scale
-      const page = await this.pdfEngine.getPage(pageNumber);
-      const viewport = page.getViewport({ scale: this.currentScale });
+    // Get PDF page and its viewport at current scale
+    const page = await this.pdfEngine.getPage(pageNumber);
+    const viewport = page.getViewport({ scale: this.currentScale });
 
-      const dimensions = {
-        width: viewport.width,
-        height: viewport.height,
-      };
+    const dimensions = {
+      width: viewport.width,
+      height: viewport.height,
+    };
 
-      // Cache the dimensions
-      this.pageDimensions.set(pageNumber, dimensions);
-      return dimensions;
-    } catch (error) {
-      console.error(`Failed to get dimensions for page ${pageNumber}:`, error);
-      return { width: 600, height: this.defaultPageHeight };
-    }
+    // Cache the dimensions
+    this.pageDimensions.set(pageNumber, dimensions);
+    return dimensions;
   }
 
   /**
@@ -503,14 +502,8 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
     this.pdfContainer.innerHTML = '';
     this.pageContainers.clear();
 
-    // Get dimensions for the first page to estimate all others
-    let avgPageHeight = this.defaultPageHeight;
-    try {
-      const firstPageDimensions = await this.getPageDimensions(1);
-      avgPageHeight = firstPageDimensions.height;
-    } catch (_error) {
-      console.warn('Could not get first page dimensions, using default');
-    }
+    const firstPageDimensions = await this.getPageDimensions(1);
+    const avgPageHeight = firstPageDimensions.height;
 
     for (let pageNumber = 1; pageNumber <= this.totalPages; pageNumber++) {
       const pageContainer = document.createElement('div');
@@ -519,15 +512,9 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
       pageContainer.style.marginBottom = '20px';
       pageContainer.style.position = 'relative';
 
-      // Try to set real dimensions, or use estimated height
-      try {
-        const dimensions = await this.getPageDimensions(pageNumber);
-        pageContainer.style.height = `${dimensions.height}px`;
-        pageContainer.style.width = `${dimensions.width}px`;
-      } catch (_error) {
-        // Use average height as fallback
-        pageContainer.style.height = `${avgPageHeight}px`;
-      }
+      const dimensions = await this.getPageDimensions(pageNumber);
+      pageContainer.style.height = `${dimensions.height}px`;
+      pageContainer.style.width = `${dimensions.width}px`;
 
       this.pdfContainer.appendChild(pageContainer);
       this.pageContainers.set(pageNumber, pageContainer);
@@ -914,9 +901,23 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
     const pageData = this.pdfEngine.getPageData(pageNumber);
     if (!pageData?.textContent) return;
 
+    const normalizedHighlights = this.highlightsIndex.highlights.map((highlight) => ({
+      ...highlight,
+      bboxes: highlight.bboxes.map((bbox) => {
+        const normalized = this.normalizeBBoxForPage(bbox, bbox.page);
+        return {
+          ...bbox,
+          x1: normalized.x1,
+          y1: normalized.y1,
+          x2: normalized.x2,
+          y2: normalized.y2,
+        };
+      }),
+    }));
+
     this.layerBuilder.updateHighlights(
       pageContainer,
-      this.highlightsIndex.highlights,
+      normalizedHighlights,
       pageNumber,
       pageData.textContent,
       this.currentScale
@@ -1087,7 +1088,14 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
     for (const h of this.highlightsIndex.highlights) {
       for (let i = 0; i < h.bboxes.length; i++) {
         const b = h.bboxes[i];
-        list.push({ termId: h.id, pageNumber: b.page, occurrenceIndex: i, x1: b.x1, y1: b.y1 });
+        const normalized = this.normalizeBBoxForPage(b, b.page);
+        list.push({
+          termId: h.id,
+          pageNumber: b.page,
+          occurrenceIndex: i,
+          x1: normalized.x1,
+          y1: normalized.y1,
+        });
       }
     }
 
@@ -1103,6 +1111,7 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
     if (!bbox) return;
 
     const page = bbox.page;
+    const normalizedBBox = this.normalizeBBoxForPage(bbox, page);
 
     this.highlightSelectedTerm(termId);
 
@@ -1117,7 +1126,7 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
         }
 
         const pageTop = pageContainer.offsetTop;
-        const y = bbox.y1 * this.currentScale;
+        const y = normalizedBBox.y1 * this.currentScale;
         this.container.scrollTop = Math.max(0, pageTop + y - 60);
 
         this.emit('navigationComplete', { termId, pageNumber: page, occurrenceIndex });
@@ -1152,7 +1161,15 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
     if (!this.container) return;
 
     const pageTop = this.getPageScrollTop(pageNumber);
-    const targetY = pageTop + y * this.currentScale - this.container.clientHeight * 0.3;
+    const origin = this.options.bboxOrigin ?? 'bottom-right';
+    const pixelDimensions = this.pageDimensions.get(pageNumber);
+    if (!pixelDimensions) {
+      throw new Error(`Page dimensions for page ${pageNumber} are not available`);
+    }
+
+    const dimensions = this.toPageCoordinateDimensions(pixelDimensions);
+    const normalizedY = origin.startsWith('bottom') ? dimensions.height - y : y;
+    const targetY = pageTop + normalizedY * this.currentScale - this.container.clientHeight * 0.3;
 
     this.container.scrollTop = Math.max(0, targetY);
 
@@ -1426,16 +1443,18 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
           const bbox = highlight.bboxes[bboxIndex];
           if (bbox.page !== pageNumber) continue;
 
+          const normalizedBBox = this.normalizeBBoxForPage(bbox, pageNumber);
+
           const highlightDiv = document.createElement('div');
           highlightDiv.className = 'highlight';
           highlightDiv.setAttribute('data-term-id', highlight.id);
           highlightDiv.setAttribute('data-page', String(pageNumber));
           highlightDiv.setAttribute('data-bbox-index', String(bboxIndex));
 
-          const left = bbox.x1 * scale;
-          const top = bbox.y1 * scale;
-          const width = (bbox.x2 - bbox.x1) * scale;
-          const height = (bbox.y2 - bbox.y1) * scale;
+          const left = normalizedBBox.x1 * scale;
+          const top = normalizedBBox.y1 * scale;
+          const width = (normalizedBBox.x2 - normalizedBBox.x1) * scale;
+          const height = (normalizedBBox.y2 - normalizedBBox.y1) * scale;
 
           highlightDiv.style.position = 'absolute';
           highlightDiv.style.left = `${left}px`;
@@ -1454,7 +1473,11 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
 
           const baseOpacity = typeof style?.opacity === 'number' ? style.opacity : 0.3;
 
-          const overlappingCount = this.countOverlappingHighlights(highlightLayer, bbox, scale);
+          const overlappingCount = this.countOverlappingHighlights(
+            highlightLayer,
+            normalizedBBox,
+            scale
+          );
           const effectiveOpacity = Math.max(
             0.05,
             baseOpacity / Math.max(1, overlappingCount * 0.7)
@@ -1632,7 +1655,58 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
    */
   private buildSpatialIndexForPage(pageNumber: number): void {
     const refs = this.highlightsIndex.pages[String(pageNumber)] ?? [];
-    this.performanceOptimizer.buildSpatialIndex(refs, pageNumber);
+    const normalizedRefs = refs.map((ref) => ({
+      ...ref,
+      bbox: this.normalizeBBoxForPage({ ...ref.bbox, page: ref.page }, ref.page),
+    }));
+    this.performanceOptimizer.buildSpatialIndex(normalizedRefs, pageNumber);
+  }
+
+  private toPageCoordinateDimensions(pixelDimensions: { width: number; height: number }): {
+    width: number;
+    height: number;
+  } {
+    const scale = this.currentScale > 0 ? this.currentScale : 1;
+    return {
+      width: pixelDimensions.width / scale,
+      height: pixelDimensions.height / scale,
+    };
+  }
+
+  private normalizeBBoxForPage(
+    bbox: BBox | (BoundingBox & { page?: number }),
+    pageNumber: number
+  ): BoundingBox {
+    const origin: BBoxOrigin = this.options.bboxOrigin ?? 'bottom-right';
+    const pixelDimensions = this.pageDimensions.get(pageNumber);
+    if (!pixelDimensions) {
+      throw new Error(`Page dimensions for page ${pageNumber} are not available`);
+    }
+
+    const { width: pageWidth, height: pageHeight } =
+      this.toPageCoordinateDimensions(pixelDimensions);
+
+    let x1 = bbox.x1;
+    let x2 = bbox.x2;
+    let y1 = bbox.y1;
+    let y2 = bbox.y2;
+
+    if (origin.endsWith('right')) {
+      x1 = pageWidth - bbox.x1;
+      x2 = pageWidth - bbox.x2;
+    }
+
+    if (origin.startsWith('bottom')) {
+      y1 = pageHeight - bbox.y1;
+      y2 = pageHeight - bbox.y2;
+    }
+
+    return {
+      x1: Math.min(x1, x2),
+      y1: Math.min(y1, y2),
+      x2: Math.max(x1, x2),
+      y2: Math.max(y1, y2),
+    };
   }
   /**
    * Build spatial indices for all pages

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export type { PDFHighlightViewer as IPDFHighlightViewer } from './api';
 
 export type {
   ViewerOptions,
+  BBoxOrigin,
   InputHighlightData,
   BBox,
   HighlightStyle,

--- a/src/types.ts
+++ b/src/types.ts
@@ -270,6 +270,8 @@ export interface HighlightsConfig {
   defaultStyle?: HighlightStyle; // optional fallback if highlight.style is missing
 }
 
+export type BBoxOrigin = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+
 export interface ViewerOptions {
   enableTextSelection?: boolean;
   enableVirtualScrolling?: boolean;
@@ -279,6 +281,7 @@ export interface ViewerOptions {
   performanceMode?: boolean;
   accessibility?: boolean;
   highlightsConfig?: HighlightsConfig;
+  bboxOrigin?: BBoxOrigin;
 }
 
 export interface ThumbnailOptions {


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->

- fixes #

### Description of changes

- Added ViewerOptions.bboxOrigin that allows configuring the origin point for bounding boxes in the viewer. Supported values are 'top-left' (default), 'top-right', 'bottom-left', and 'bottom-right'. This affects how highlights are rendered, how navigation works, and how spatial indexing is performed.
- Added a demonstration of the bbox origin selector in the SimpleExample component.
- Updated documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
