### PR TITLE
feat: add optional highlight/global bbox normalization settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ export interface BBox {
   page: number;
 }
 
+export interface BBoxDimensions {
+  width: number;
+  height: number;
+}
+
 export interface HighlightStyle {
   backgroundColor: string;
   borderColor?: string;
@@ -116,6 +121,8 @@ export interface HighlightLabelStyle {
 export interface InputHighlightData {
   id: string;
   bboxes: BBox[];
+  bboxOrigin?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+  bboxSourceDimensions?: BBoxDimensions;
   style?: HighlightStyle;
   label?: string;
   beforeIcon?: string; // inline SVG string (trusted content only, e.g. Tabler icons)
@@ -124,6 +131,18 @@ export interface InputHighlightData {
   metadata?: Record<string, any>;
 }
 ```
+
+If `bboxSourceDimensions` is provided, each bbox coordinate is recalculated against the actual page size:
+
+```ts
+scaledX = (x / bboxSourceDimensions.width) * actualPageWidth;
+scaledY = (y / bboxSourceDimensions.height) * actualPageHeight;
+```
+
+Priority (highest to lowest):
+
+- `highlight.bboxOrigin` / `highlight.bboxSourceDimensions`
+- global viewer options (`bboxOrigin`, `bboxSourceDimensions`)
 
 ## Configuration Options
 
@@ -160,6 +179,9 @@ interface ViewerConfig {
   // Coordinate origin for incoming bbox values
   // Default: 'bottom-right'
   bboxOrigin?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+
+  // Page dimensions for which bbox coordinates were calculated
+  bboxSourceDimensions?: { width: number; height: number };
 }
 ```
 

--- a/example/src/components/SimpleExample.tsx
+++ b/example/src/components/SimpleExample.tsx
@@ -17,6 +17,7 @@ const ICON_ALERT_CIRCLE_SVG =
 const initialHighlights: InputHighlightData[] = [
   {
     id: 'red-zone',
+    bboxOrigin: 'top-left',
     bboxes: [{ x1: 180, y1: 110, x2: 340, y2: 130, page: 1 }],
     style: { backgroundColor: '#ff6b6b', opacity: 0.4 },
     label: 'Red zone',
@@ -43,6 +44,8 @@ const initialHighlights: InputHighlightData[] = [
   },
   {
     id: 'green-zone',
+    // Coordinates were generated on a 1200x1000 source canvas and are scaled to real page size.
+    bboxSourceDimensions: { width: 1200, height: 1000 },
     bboxes: [
       { x1: 90, y1: 250, x2: 280, y2: 270, page: 2 },
       { x1: 300, y1: 300, x2: 450, y2: 320, page: 3 },

--- a/src/PDFHighlightViewer.ts
+++ b/src/PDFHighlightViewer.ts
@@ -3,6 +3,7 @@ import {
   ViewerOptions,
   BBoxOrigin,
   BBox,
+  BBoxDimensions,
   BoundingBox,
   TextRange,
   SelectionWithMetadata,
@@ -904,7 +905,12 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
     const normalizedHighlights = this.highlightsIndex.highlights.map((highlight) => ({
       ...highlight,
       bboxes: highlight.bboxes.map((bbox) => {
-        const normalized = this.normalizeBBoxForPage(bbox, bbox.page);
+        const normalized = this.normalizeBBoxForPage(
+          bbox,
+          bbox.page,
+          highlight.bboxSourceDimensions,
+          highlight.bboxOrigin
+        );
         return {
           ...bbox,
           x1: normalized.x1,
@@ -1088,7 +1094,12 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
     for (const h of this.highlightsIndex.highlights) {
       for (let i = 0; i < h.bboxes.length; i++) {
         const b = h.bboxes[i];
-        const normalized = this.normalizeBBoxForPage(b, b.page);
+        const normalized = this.normalizeBBoxForPage(
+          b,
+          b.page,
+          h.bboxSourceDimensions,
+          h.bboxOrigin
+        );
         list.push({
           termId: h.id,
           pageNumber: b.page,
@@ -1111,7 +1122,12 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
     if (!bbox) return;
 
     const page = bbox.page;
-    const normalizedBBox = this.normalizeBBoxForPage(bbox, page);
+    const normalizedBBox = this.normalizeBBoxForPage(
+      bbox,
+      page,
+      highlight.bboxSourceDimensions,
+      highlight.bboxOrigin
+    );
 
     this.highlightSelectedTerm(termId);
 
@@ -1443,7 +1459,12 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
           const bbox = highlight.bboxes[bboxIndex];
           if (bbox.page !== pageNumber) continue;
 
-          const normalizedBBox = this.normalizeBBoxForPage(bbox, pageNumber);
+          const normalizedBBox = this.normalizeBBoxForPage(
+            bbox,
+            pageNumber,
+            highlight.bboxSourceDimensions,
+            highlight.bboxOrigin
+          );
 
           const highlightDiv = document.createElement('div');
           highlightDiv.className = 'highlight';
@@ -1664,10 +1685,21 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
    */
   private buildSpatialIndexForPage(pageNumber: number): void {
     const refs = this.highlightsIndex.pages[String(pageNumber)] ?? [];
-    const normalizedRefs = refs.map((ref) => ({
-      ...ref,
-      bbox: this.normalizeBBoxForPage({ ...ref.bbox, page: ref.page }, ref.page),
-    }));
+    const normalizedRefs = refs.map((ref) => {
+      const highlight = this.highlightsIndex.byId.get(ref.id);
+      return {
+        ...ref,
+        bbox: this.normalizeBBoxForPage(
+          highlight?.bboxes[ref.bboxIndex] ?? {
+            ...ref.bbox,
+            page: ref.page,
+          },
+          ref.page,
+          highlight?.bboxSourceDimensions,
+          highlight?.bboxOrigin
+        ),
+      };
+    });
     this.performanceOptimizer.buildSpatialIndex(normalizedRefs, pageNumber);
   }
 
@@ -1684,9 +1716,12 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
 
   private normalizeBBoxForPage(
     bbox: BBox | (BoundingBox & { page?: number }),
-    pageNumber: number
+    pageNumber: number,
+    bboxSourceDimensions?: BBoxDimensions,
+    bboxOrigin?: BBoxOrigin
   ): BoundingBox {
-    const origin: BBoxOrigin = this.options.bboxOrigin ?? 'bottom-right';
+    const origin: BBoxOrigin = bboxOrigin ?? this.options.bboxOrigin ?? 'bottom-right';
+    const computedSourceDimensions = bboxSourceDimensions ?? this.options.bboxSourceDimensions;
     const pixelDimensions = this.pageDimensions.get(pageNumber);
     if (!pixelDimensions) {
       throw new Error(`Page dimensions for page ${pageNumber} are not available`);
@@ -1700,14 +1735,27 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
     let y1 = bbox.y1;
     let y2 = bbox.y2;
 
+    if (
+      computedSourceDimensions &&
+      computedSourceDimensions.width &&
+      computedSourceDimensions.height
+    ) {
+      const xScale = pageWidth / computedSourceDimensions.width;
+      const yScale = pageHeight / computedSourceDimensions.height;
+      x1 *= xScale;
+      x2 *= xScale;
+      y1 *= yScale;
+      y2 *= yScale;
+    }
+
     if (origin.endsWith('right')) {
-      x1 = pageWidth - bbox.x1;
-      x2 = pageWidth - bbox.x2;
+      x1 = pageWidth - x1;
+      x2 = pageWidth - x2;
     }
 
     if (origin.startsWith('bottom')) {
-      y1 = pageHeight - bbox.y1;
-      y2 = pageHeight - bbox.y2;
+      y1 = pageHeight - y1;
+      y2 = pageHeight - y2;
     }
 
     return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,9 +47,16 @@ export interface HighlightLabelStyle {
   iconColor?: string;
 }
 
+export interface BBoxDimensions {
+  width: number;
+  height: number;
+}
+
 export interface InputHighlightData {
   id: string;
   bboxes: BBox[];
+  bboxOrigin?: BBoxOrigin;
+  bboxSourceDimensions?: BBoxDimensions;
   style?: HighlightStyle;
   label?: string;
   /** Inline SVG string (e.g. from Tabler) to render before the label inside the label frame. Use trusted content only. */
@@ -282,6 +289,7 @@ export interface ViewerOptions {
   accessibility?: boolean;
   highlightsConfig?: HighlightsConfig;
   bboxOrigin?: BBoxOrigin;
+  bboxSourceDimensions?: BBoxDimensions;
 }
 
 export interface ThumbnailOptions {


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->

- fixes #

### Description of changes

Added optional bbox normalization settings in global and per-highlight settings.

- added optional bbox source dimensions to rescale coordinates to the actual page size. It's useful when bbox coordinates were produced against a different page dimension.
- aligned bboxOrigin with the same configuration model, supporting both global and per-highlight usage for consistency.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
