### PR TITLE
feat: added ability to set page rotation

### DIFF
--- a/example/src/components/SimpleExample.tsx
+++ b/example/src/components/SimpleExample.tsx
@@ -2,14 +2,37 @@ import {
   BBoxOrigin,
   HighlightStyle,
   InputHighlightData,
+  PageRotationDegrees,
   PDFHighlightViewer,
+  RotationDirection,
   ZoomMode,
 } from '../../../src';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  type CSSProperties,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { ButtonVariant, DialButton, DialDropdown } from '@epam/ai-dial-ui-kit';
 import '@epam/ai-dial-ui-kit/styles.css';
 
 const PDF_URL = 'https://ontheline.trincoll.edu/images/bookdown/sample-local-pdf.pdf';
+
+const toolbarSelectStyle: CSSProperties = {
+  background: 'rgba(255,255,255,0.08)',
+  color: '#ffffff',
+  border: '1px solid rgba(255,255,255,0.25)',
+  borderRadius: 6,
+  padding: '4px 8px',
+  height: 30,
+};
+
+const toolbarSelectOptionStyle: CSSProperties = {
+  background: '#23252a',
+  color: '#ffffff',
+};
 
 const ICON_ALERT_CIRCLE_SVG =
   '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8v4"/><path d="M12 16h.01"/><circle cx="12" cy="12" r="10"/></svg>';
@@ -149,6 +172,12 @@ export const SimpleExample: React.FC = () => {
   const [performanceMode, setPerformanceMode] = useState(false);
   const [bboxOrigin, setBBoxOrigin] = useState<BBoxOrigin>('top-left');
 
+  const [displayRotationPage, setDisplayRotationPage] = useState(1);
+  const [displayRotationDegrees, setDisplayRotationDegrees] = useState<PageRotationDegrees>(0);
+  const [displayRotationDirection, setDisplayRotationDirection] = useState(
+    RotationDirection.Clockwise
+  );
+
   // Debug state (from events)
   const [totalPages, setTotalPages] = useState<number | null>(null);
   const [currentPage, setCurrentPage] = useState<number>(1);
@@ -180,6 +209,11 @@ export const SimpleExample: React.FC = () => {
     setEvents([]);
     pushEvent('ui.clearEvents', {});
   }, [pushEvent]);
+
+  useEffect(() => {
+    if (totalPages == null || totalPages < 1) return;
+    setDisplayRotationPage((p) => Math.min(Math.max(1, p), totalPages));
+  }, [totalPages]);
 
   const reinitViewer = useCallback(() => {
     setRenderedPages(new Set());
@@ -362,6 +396,42 @@ export const SimpleExample: React.FC = () => {
     [highlights, pushEvent]
   );
 
+  const onDisplayRotationPageChange = useCallback(
+    (page: number) => {
+      setDisplayRotationPage(page);
+      viewerRef.current?.setPageDisplayRotation(
+        page,
+        displayRotationDegrees,
+        displayRotationDirection
+      );
+    },
+    [displayRotationDegrees, displayRotationDirection]
+  );
+
+  const onDisplayRotationDegreesChange = useCallback(
+    (degrees: PageRotationDegrees) => {
+      setDisplayRotationDegrees(degrees);
+      viewerRef.current?.setPageDisplayRotation(
+        displayRotationPage,
+        degrees,
+        displayRotationDirection
+      );
+    },
+    [displayRotationPage, displayRotationDirection]
+  );
+
+  const onDisplayRotationDirectionChange = useCallback(
+    (direction: RotationDirection) => {
+      setDisplayRotationDirection(direction);
+      viewerRef.current?.setPageDisplayRotation(
+        displayRotationPage,
+        displayRotationDegrees,
+        direction
+      );
+    },
+    [displayRotationPage, displayRotationDegrees]
+  );
+
   useEffect(() => {
     if (!containerRef.current) return;
 
@@ -426,6 +496,7 @@ export const SimpleExample: React.FC = () => {
           { event: 'highlightBlur', cb: on('highlightBlur') },
 
           { event: 'pageChanged', cb: on('pageChanged') },
+          { event: 'pageRotationChanged', cb: on('pageRotationChanged') },
           { event: 'zoomChanged', cb: on('zoomChanged') },
 
           { event: 'navigationComplete', cb: on('navigationComplete') },
@@ -762,26 +833,68 @@ export const SimpleExample: React.FC = () => {
             <select
               value={bboxOrigin}
               onChange={(e) => onBBoxOriginChange(e.target.value as BBoxOrigin)}
-              style={{
-                background: 'rgba(255,255,255,0.08)',
-                color: '#ffffff',
-                border: '1px solid rgba(255,255,255,0.25)',
-                borderRadius: 6,
-                padding: '4px 8px',
-                height: 30,
-              }}
+              style={toolbarSelectStyle}
             >
-              <option value="bottom-right" style={{ background: '#23252a', color: '#ffffff' }}>
+              <option value="bottom-right" style={toolbarSelectOptionStyle}>
                 bottom-right
               </option>
-              <option value="bottom-left" style={{ background: '#23252a', color: '#ffffff' }}>
+              <option value="bottom-left" style={toolbarSelectOptionStyle}>
                 bottom-left
               </option>
-              <option value="top-right" style={{ background: '#23252a', color: '#ffffff' }}>
+              <option value="top-right" style={toolbarSelectOptionStyle}>
                 top-right
               </option>
-              <option value="top-left" style={{ background: '#23252a', color: '#ffffff' }}>
+              <option value="top-left" style={toolbarSelectOptionStyle}>
                 top-left
+              </option>
+            </select>
+          </label>
+
+          <label style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+            page rotation
+            <select
+              value={displayRotationPage}
+              onChange={(e) => onDisplayRotationPageChange(Number(e.target.value))}
+              style={toolbarSelectStyle}
+            >
+              {Array.from({ length: Math.max(totalPages ?? 5, 1) }, (_, i) => i + 1).map((p) => (
+                <option key={p} value={p} style={toolbarSelectOptionStyle}>
+                  {p}
+                </option>
+              ))}
+            </select>
+            <select
+              value={displayRotationDegrees}
+              onChange={(e) =>
+                onDisplayRotationDegreesChange(Number(e.target.value) as PageRotationDegrees)
+              }
+              style={toolbarSelectStyle}
+            >
+              <option value={0} style={toolbarSelectOptionStyle}>
+                0°
+              </option>
+              <option value={90} style={toolbarSelectOptionStyle}>
+                90°
+              </option>
+              <option value={180} style={toolbarSelectOptionStyle}>
+                180°
+              </option>
+              <option value={270} style={toolbarSelectOptionStyle}>
+                270°
+              </option>
+            </select>
+            <select
+              value={displayRotationDirection}
+              onChange={(e) =>
+                onDisplayRotationDirectionChange(e.target.value as RotationDirection)
+              }
+              style={toolbarSelectStyle}
+            >
+              <option value={RotationDirection.Clockwise} style={toolbarSelectOptionStyle}>
+                CW
+              </option>
+              <option value={RotationDirection.CounterClockwise} style={toolbarSelectOptionStyle}>
+                CCW
               </option>
             </select>
           </label>
@@ -805,7 +918,8 @@ export const SimpleExample: React.FC = () => {
         </div>
 
         <div style={{ fontSize: 12, opacity: 0.75, marginTop: 4 }}>
-          Note: bbox origin applies immediately; other options require <b>Reinit</b>.
+          Note: bbox origin and page rotation apply immediately. After <b>Reinit</b>, set page
+          rotation again if needed. Other options require <b>Reinit</b>.
         </div>
       </div>
 

--- a/src/PDFHighlightViewer.ts
+++ b/src/PDFHighlightViewer.ts
@@ -20,10 +20,12 @@ import {
   ZoomValue,
   ZoomMode,
   ThumbnailOptions,
+  PageRotationDegrees,
+  RotationDirection,
 } from './types';
 import { PDFEngine } from './core/pdf-engine';
 import { ViewportManager } from './core/viewport-manager';
-import { UnifiedLayerBuilder } from './core/unified-layer-builder';
+import { UnifiedLayerBuilder, TextLayerViewport } from './core/unified-layer-builder';
 import { UnifiedInteractionHandler, InteractionCallbacks } from './core/interaction-handler';
 import { PerformanceOptimizer } from './core/performance-optimizer';
 import { buildHighlightsIndex } from './utils/highlight-adapter';
@@ -40,6 +42,12 @@ import {
   applyLabelStyle,
   scaleLabelStyle,
 } from './utils/label-style';
+import {
+  clockwiseToCcw,
+  displayRotationToClockwise,
+  rotateBoundingBoxForCcwRotation,
+} from './utils/rotate-bbox';
+import { sumPdfIntrinsicAndUserRotation } from './utils/pdf-rotation-math';
 
 const CONTAINER_PADDING = 40;
 const ZOOM_STEP = 1.2;
@@ -76,6 +84,10 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
   private navIndex = -1;
 
   private pageDimensions = new Map<number, { width: number; height: number }>();
+  /** Intrinsic page size in normalized units (PDF default viewport at currentScale / scale). */
+  private intrinsicPageNormalized = new Map<number, { width: number; height: number }>();
+  /** Extra clockwise rotation per page on top of PDF `/Rotate`. */
+  private pageDisplayRotations = new Map<number, PageRotationDegrees>();
   private defaultPageHeight = 800;
 
   private eventListeners: { event: string; callback: EventCallback }[] = [];
@@ -154,8 +166,22 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
       this.setupAccessibility();
     }
 
+    this.syncPageDisplayRotationsFromOptions();
+
     this.isInitialized = true;
     this.emit('initialized');
+  }
+
+  private syncPageDisplayRotationsFromOptions(): void {
+    this.pageDisplayRotations.clear();
+    const raw = this.options.pageDisplayRotations;
+    if (!raw) return;
+    for (const [key, value] of Object.entries(raw)) {
+      const n = Number(key);
+      if (Number.isInteger(n) && n >= 1) {
+        this.pageDisplayRotations.set(n, value);
+      }
+    }
   }
 
   /**
@@ -404,24 +430,49 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
     }
   }
 
+  private getUserClockwiseRotation(pageNumber: number): PageRotationDegrees {
+    return this.pageDisplayRotations.get(pageNumber) ?? 0;
+  }
+
+  private effectiveViewportRotationDegrees(
+    intrinsicRotateDegrees: number,
+    pageNumber: number
+  ): number {
+    return sumPdfIntrinsicAndUserRotation(
+      intrinsicRotateDegrees,
+      this.getUserClockwiseRotation(pageNumber)
+    );
+  }
+
   /**
-   * Get and cache real page dimensions
+   * Get and cache display page dimensions (rotated viewport pixels at currentScale)
+   * and intrinsic normalized size for highlight mapping.
    */
   private async getPageDimensions(pageNumber: number): Promise<{ width: number; height: number }> {
-    // Return cached dimensions if available
-    const cached = this.pageDimensions.get(pageNumber);
-    if (cached) return cached;
+    const cachedDisplay = this.pageDimensions.get(pageNumber);
+    const cachedIntrinsic = this.intrinsicPageNormalized.get(pageNumber);
+    if (cachedDisplay && cachedIntrinsic) {
+      return cachedDisplay;
+    }
 
-    // Get PDF page and its viewport at current scale
-    const page = await this.pdfEngine.getPage(pageNumber);
-    const viewport = page.getViewport({ scale: this.currentScale });
+    const pdfPage = await this.pdfEngine.getPage(pageNumber);
+    const intrinsicVp = pdfPage.getViewport({ scale: this.currentScale });
+    const scale = this.currentScale > 0 ? this.currentScale : 1;
+    this.intrinsicPageNormalized.set(pageNumber, {
+      width: intrinsicVp.width / scale,
+      height: intrinsicVp.height / scale,
+    });
+
+    const effectiveRotation = this.effectiveViewportRotationDegrees(pdfPage.rotate, pageNumber);
+    const displayVp = pdfPage.getViewport({
+      scale: this.currentScale,
+      rotation: effectiveRotation,
+    });
 
     const dimensions = {
-      width: viewport.width,
-      height: viewport.height,
+      width: displayVp.width,
+      height: displayVp.height,
     };
-
-    // Cache the dimensions
     this.pageDimensions.set(pageNumber, dimensions);
     return dimensions;
   }
@@ -496,6 +547,8 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
 
       const docInfo = this.pdfEngine.getDocumentInfo();
       this.documentNumPages = docInfo.numPages;
+
+      this.syncPageDisplayRotationsFromOptions();
 
       const rawSelected = options?.selectedPages ?? this.options.selectedPages;
       const selectedPages = this.normalizeSelectedPages(rawSelected, this.documentNumPages);
@@ -648,8 +701,16 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
       // Add loading state
       pageContainer.classList.add('loading');
 
+      const pdfPage = await this.pdfEngine.getPage(pageNumber);
+      const effectiveRotation = this.effectiveViewportRotationDegrees(pdfPage.rotate, pageNumber);
+
       // Render PDF canvas
-      const canvas = await this.pdfEngine.renderPage(pageNumber, this.currentScale);
+      const canvas = await this.pdfEngine.renderPage(
+        pageNumber,
+        this.currentScale,
+        undefined,
+        effectiveRotation
+      );
 
       // Clear container and add canvas
       pageContainer.innerHTML = '';
@@ -733,8 +794,10 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
     if (!this.container) {
       return { scaleX: 1, scaleY: 1 };
     }
-    const page = await this.pdfEngine.getPage(this.currentPage || 1);
-    const viewport = page.getViewport({ scale: 1 });
+    const pageNum = this.currentPage || 1;
+    const page = await this.pdfEngine.getPage(pageNum);
+    const effectiveRotation = this.effectiveViewportRotationDegrees(page.rotate, pageNum);
+    const viewport = page.getViewport({ scale: 1, rotation: effectiveRotation });
     const scaleX = (this.container.clientWidth - CONTAINER_PADDING) / viewport.width;
     const scaleY = (this.container.clientHeight - CONTAINER_PADDING) / viewport.height;
     return { scaleX, scaleY };
@@ -760,11 +823,46 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
     return this.totalPages;
   }
 
+  setPageDisplayRotation(
+    pageNumber: number,
+    degrees: PageRotationDegrees,
+    direction: RotationDirection = RotationDirection.Clockwise
+  ): void {
+    if (degrees === 0) {
+      this.pageDisplayRotations.delete(pageNumber);
+      if (this.options.pageDisplayRotations) {
+        const next = { ...this.options.pageDisplayRotations };
+        delete next[pageNumber];
+        this.options.pageDisplayRotations = Object.keys(next).length > 0 ? next : undefined;
+      }
+    } else {
+      const cw = displayRotationToClockwise(degrees, direction);
+      this.pageDisplayRotations.set(pageNumber, cw);
+      this.options.pageDisplayRotations = {
+        ...(this.options.pageDisplayRotations ?? {}),
+        [pageNumber]: cw,
+      };
+    }
+
+    void this.reRenderVisiblePages();
+    this.emit('pageRotationChanged', { pageNumber, degrees, direction });
+  }
+
+  getPageDisplayRotation(pageNumber: number): PageRotationDegrees {
+    return this.pageDisplayRotations.get(pageNumber) ?? 0;
+  }
+
   async getThumbnails(
     pageNumbers: number[],
     options?: ThumbnailOptions
   ): Promise<Map<number, HTMLCanvasElement>> {
-    return this.pdfEngine.getThumbnails(pageNumbers, options);
+    const viewportRotations: Record<number, number> = { ...(options?.viewportRotations ?? {}) };
+    for (const n of pageNumbers) {
+      if (viewportRotations[n] !== undefined) continue;
+      const pdfPage = await this.pdfEngine.getPage(n);
+      viewportRotations[n] = this.effectiveViewportRotationDegrees(pdfPage.rotate, n);
+    }
+    return this.pdfEngine.getThumbnails(pageNumbers, { ...options, viewportRotations });
   }
 
   async getThumbnailsDataUrl(
@@ -880,7 +978,7 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
     // Refresh only affected pages
     for (const pageNumber of affectedPages) {
       this.refreshHighlightLayerForPage(pageNumber);
-      this.updatePageUnifiedLayer(pageNumber);
+      void this.updatePageUnifiedLayer(pageNumber);
       this.buildSpatialIndexForPage(pageNumber);
     }
 
@@ -908,7 +1006,7 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
 
     for (const pageNumber of affectedPages) {
       this.refreshHighlightLayerForPage(pageNumber);
-      this.updatePageUnifiedLayer(pageNumber);
+      void this.updatePageUnifiedLayer(pageNumber);
       this.buildSpatialIndexForPage(pageNumber);
     }
 
@@ -952,7 +1050,7 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
 
     for (const pageNumber of affectedPages) {
       this.refreshHighlightLayerForPage(pageNumber);
-      this.updatePageUnifiedLayer(pageNumber);
+      void this.updatePageUnifiedLayer(pageNumber);
       this.buildSpatialIndexForPage(pageNumber);
     }
 
@@ -962,7 +1060,7 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
   /**
    * Update unified layer for a specific page
    */
-  private updatePageUnifiedLayer(pageNumber: number): void {
+  private async updatePageUnifiedLayer(pageNumber: number): Promise<void> {
     const pageContainer = this.pageContainers.get(pageNumber);
     if (!pageContainer) return;
 
@@ -988,12 +1086,25 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
       }),
     }));
 
+    let viewport: TextLayerViewport | undefined;
+    try {
+      const pdfPage = await this.pdfEngine.getPage(pageNumber);
+      const effectiveRotation = this.effectiveViewportRotationDegrees(pdfPage.rotate, pageNumber);
+      viewport = pdfPage.getViewport({
+        scale: this.currentScale,
+        rotation: effectiveRotation,
+      });
+    } catch {
+      viewport = undefined;
+    }
+
     this.layerBuilder.updateHighlights(
       pageContainer,
       normalizedHighlights,
       pageNumber,
       pageData.textContent,
-      this.currentScale
+      this.currentScale,
+      viewport
     );
   }
   /**
@@ -1028,7 +1139,8 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
 
     // Clear ALL cached data for the new scale
     this.pdfEngine.clearAllPageCache();
-    this.pageDimensions.clear(); // Clear dimension cache
+    this.pageDimensions.clear();
+    this.intrinsicPageNormalized.clear();
 
     // Clear all containers and update their sizes for new scale
     let totalHeight = 0;
@@ -1249,15 +1361,14 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
     if (!this.container) return;
 
     const pageTop = this.getPageScrollTop(pageNumber);
-    const origin = this.options.bboxOrigin ?? 'bottom-right';
-    const pixelDimensions = this.pageDimensions.get(pageNumber);
-    if (!pixelDimensions) {
-      throw new Error(`Page dimensions for page ${pageNumber} are not available`);
-    }
-
-    const dimensions = this.toPageCoordinateDimensions(pixelDimensions);
-    const normalizedY = origin.startsWith('bottom') ? dimensions.height - y : y;
-    const targetY = pageTop + normalizedY * this.currentScale - this.container.clientHeight * 0.3;
+    const normalizedBBox = this.normalizeBBoxForPage(
+      { page: pageNumber, x1: x, y1: y, x2: x, y2: y },
+      pageNumber,
+      this.options.bboxSourceDimensions,
+      this.options.bboxOrigin
+    );
+    const targetY =
+      pageTop + normalizedBBox.y1 * this.currentScale - this.container.clientHeight * 0.3;
 
     this.container.scrollTop = Math.max(0, targetY);
 
@@ -1888,13 +1999,13 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
   ): BoundingBox {
     const origin: BBoxOrigin = bboxOrigin ?? this.options.bboxOrigin ?? 'bottom-right';
     const computedSourceDimensions = bboxSourceDimensions ?? this.options.bboxSourceDimensions;
-    const pixelDimensions = this.pageDimensions.get(pageNumber);
-    if (!pixelDimensions) {
+    const intrinsic = this.intrinsicPageNormalized.get(pageNumber);
+    if (!intrinsic) {
       throw new Error(`Page dimensions for page ${pageNumber} are not available`);
     }
 
-    const { width: pageWidth, height: pageHeight } =
-      this.toPageCoordinateDimensions(pixelDimensions);
+    const pageWidth = intrinsic.width;
+    const pageHeight = intrinsic.height;
 
     let x1 = bbox.x1;
     let x2 = bbox.x2;
@@ -1924,12 +2035,20 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
       y2 = pageHeight - y2;
     }
 
-    return {
+    let result: BoundingBox = {
       x1: Math.min(x1, x2),
       y1: Math.min(y1, y2),
       x2: Math.max(x1, x2),
       y2: Math.max(y1, y2),
     };
+
+    const userCw = this.getUserClockwiseRotation(pageNumber);
+    if (userCw !== 0) {
+      const ccw = clockwiseToCcw(userCw);
+      result = rotateBoundingBoxForCcwRotation(result, pageWidth, pageHeight, ccw);
+    }
+
+    return result;
   }
   /**
    * Build spatial indices for displayed pages only
@@ -2087,9 +2206,12 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
     }
 
     try {
-      // Get the PDF page and its viewport
       const pdfPage = await this.pdfEngine.getPage(pageNumber);
-      const viewport = pdfPage.getViewport({ scale: this.currentScale });
+      const effectiveRotation = this.effectiveViewportRotationDegrees(pdfPage.rotate, pageNumber);
+      const viewport = pdfPage.getViewport({
+        scale: this.currentScale,
+        rotation: effectiveRotation,
+      });
 
       // Extract text content from PDF
       const textContent = await pdfPage.getTextContent();
@@ -2323,6 +2445,9 @@ export class PDFHighlightViewer implements IPDFHighlightViewer {
     // Clear state
     this.eventListeners = [];
     this.isInitialized = false;
+    this.pageDimensions.clear();
+    this.intrinsicPageNormalized.clear();
+    this.pageDisplayRotations.clear();
 
     this.emit('destroyed');
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -13,6 +13,8 @@ import {
   HighlightLabelStyle,
   ZoomValue,
   ThumbnailOptions,
+  PageRotationDegrees,
+  RotationDirection,
 } from './types';
 
 export interface PDFHighlightViewer {
@@ -31,6 +33,18 @@ export interface PDFHighlightViewer {
   getCurrentPage(): number;
 
   getTotalPages(): number;
+
+  /**
+   * Set extra clockwise display rotation for a page (on top of PDF intrinsic rotation).
+   * Pass degrees 0 to clear. For non-zero, direction selects CW vs CCW for that angle.
+   */
+  setPageDisplayRotation(
+    pageNumber: number,
+    degrees: PageRotationDegrees,
+    direction?: RotationDirection
+  ): void;
+
+  getPageDisplayRotation(pageNumber: number): PageRotationDegrees;
 
   getThumbnails(
     pageNumbers: number[],

--- a/src/core/pdf-engine.ts
+++ b/src/core/pdf-engine.ts
@@ -38,8 +38,13 @@ export class PDFEngine {
   private static readonly THUMBNAIL_DEFAULT_SCALE = 0.2;
   private static readonly THUMBNAIL_RENDER_CONCURRENCY = 3;
 
-  private static getThumbnailCacheKey(pageNumber: number, scale: number): string {
-    return `${pageNumber}:${scale.toFixed(4)}`;
+  private static getThumbnailCacheKey(
+    pageNumber: number,
+    scale: number,
+    rotation?: number
+  ): string {
+    const r = rotation === undefined ? 'def' : String(rotation);
+    return `${pageNumber}:${scale.toFixed(4)}:${r}`;
   }
 
   constructor(private options: ViewerOptions = {}) {
@@ -141,24 +146,35 @@ export class PDFEngine {
   async renderPage(
     pageNumber: number,
     scale = 1.5,
-    canvas?: HTMLCanvasElement
+    canvas?: HTMLCanvasElement,
+    rotation?: number
   ): Promise<HTMLCanvasElement> {
     const pageData = this.pages.get(pageNumber);
     if (!pageData) {
       throw new Error(`Page ${pageNumber} not found`);
     }
 
-    if (pageData.rendered && pageData.canvas && pageData.scale === scale) {
+    const page = await this.getPage(pageNumber);
+    const viewport =
+      rotation !== undefined ? page.getViewport({ scale, rotation }) : page.getViewport({ scale });
+    const effectiveRotation = viewport.rotation;
+
+    if (
+      pageData.rendered &&
+      pageData.canvas &&
+      pageData.scale === scale &&
+      pageData.viewportRotation === effectiveRotation
+    ) {
       return pageData.canvas;
     }
 
-    if (pageData.rendered && pageData.scale !== scale) {
+    if (
+      pageData.rendered &&
+      (pageData.scale !== scale || pageData.viewportRotation !== effectiveRotation)
+    ) {
       pageData.rendered = false;
       pageData.canvas = undefined;
     }
-
-    const page = await this.getPage(pageNumber);
-    const viewport = page.getViewport({ scale });
 
     const renderCanvas = canvas || this.getCanvasFromPool();
     const context = renderCanvas.getContext('2d');
@@ -185,6 +201,7 @@ export class PDFEngine {
       pageData.rendered = true;
       pageData.loading = false;
       pageData.scale = scale;
+      pageData.viewportRotation = effectiveRotation;
 
       this.pages.set(pageNumber, pageData);
 
@@ -284,6 +301,7 @@ export class PDFEngine {
         page.canvas = undefined;
         page.rendered = false;
         page.textContent = undefined;
+        page.viewportRotation = undefined;
 
         this.pages.set(pageNumber, page);
       }
@@ -325,19 +343,27 @@ export class PDFEngine {
     }
 
     const page = await this.getPage(pageNumber);
+    const rotation = options?.viewportRotations?.[pageNumber];
+
     let scale = options?.scale ?? PDFEngine.THUMBNAIL_DEFAULT_SCALE;
     if (options?.maxWidth != null && options.maxWidth > 0) {
-      const baseViewport = page.getViewport({ scale: 1 });
+      const baseViewport = page.getViewport({
+        scale: 1,
+        ...(rotation !== undefined ? { rotation } : {}),
+      });
       scale = options.maxWidth / baseViewport.width;
     }
 
-    const cacheKey = PDFEngine.getThumbnailCacheKey(pageNumber, scale);
+    const cacheKey = PDFEngine.getThumbnailCacheKey(pageNumber, scale, rotation);
     const cached = this.thumbnailCache.get(cacheKey);
     if (cached) {
       return cached;
     }
 
-    const viewport = page.getViewport({ scale });
+    const viewport = page.getViewport({
+      scale,
+      ...(rotation !== undefined ? { rotation } : {}),
+    });
 
     const canvas = document.createElement('canvas');
     canvas.width = viewport.width;
@@ -402,6 +428,7 @@ export class PDFEngine {
       page.rendered = false;
       page.textContent = undefined;
       page.scale = undefined;
+      page.viewportRotation = undefined;
       this.pages.set(pageNumber, page);
     });
   }

--- a/src/core/pdf-engine.ts
+++ b/src/core/pdf-engine.ts
@@ -37,13 +37,15 @@ export class PDFEngine {
   private thumbnailCache = new Map<string, HTMLCanvasElement>();
   private static readonly THUMBNAIL_DEFAULT_SCALE = 0.2;
   private static readonly THUMBNAIL_RENDER_CONCURRENCY = 3;
+  /** Cache key token when rotation is omitted — PDF.js uses intrinsic page rotation, not rotation 0. */
+  private static readonly THUMBNAIL_CACHE_INTRINSIC_ROTATION = 'def';
 
   private static getThumbnailCacheKey(
     pageNumber: number,
     scale: number,
     rotation?: number
   ): string {
-    const r = rotation === undefined ? 'def' : String(rotation);
+    const r = rotation === undefined ? this.THUMBNAIL_CACHE_INTRINSIC_ROTATION : String(rotation);
     return `${pageNumber}:${scale.toFixed(4)}:${r}`;
   }
 

--- a/src/core/unified-layer-builder.ts
+++ b/src/core/unified-layer-builder.ts
@@ -115,7 +115,7 @@ export class UnifiedLayerBuilder {
 
     textContent.items.forEach((textItem) => {
       const itemBounds = viewport
-        ? this.getTextItemBoundsDisplayNormalized(textItem, viewport, scale)
+        ? this.getRotatedTextItemBounds(textItem, viewport, scale)
         : this.getTextItemBounds(textItem);
       const itemHighlights = this.getHighlightsForTextItem(itemBounds, pageHighlights);
 
@@ -355,7 +355,7 @@ export class UnifiedLayerBuilder {
   }
 
   /** Bounds in the same normalized display space as rotated highlight bboxes (divide viewport px by scale). */
-  private getTextItemBoundsDisplayNormalized(
+  private getRotatedTextItemBounds(
     item: TextItem,
     viewport: TextLayerViewport,
     scale: number

--- a/src/core/unified-layer-builder.ts
+++ b/src/core/unified-layer-builder.ts
@@ -20,6 +20,11 @@ import {
   resolveHighlightStyle,
 } from '../utils/highlight-style';
 
+/** PDF.js viewport (or compatible) for positioning text in rotated display space. */
+export interface TextLayerViewport {
+  convertToViewportPoint: (x: number, y: number) => number[];
+}
+
 interface ItemHighlight {
   termId: string;
   coordinates: BoundingBox;
@@ -42,15 +47,22 @@ export class UnifiedLayerBuilder {
     textContent: TextContent,
     highlights: InputHighlightData[],
     pageNumber: number,
-    scale = 1.5
+    scale = 1.5,
+    viewport?: TextLayerViewport
   ): HTMLElement {
     this.pageContainer = pageContainer;
 
     const existing = pageContainer.querySelector('.unified-layer');
     if (existing) existing.remove();
 
-    const segments = this.segmentTextWithHighlights(textContent, highlights, pageNumber);
-    const unifiedLayer = this.buildDOM(segments, scale);
+    const segments = this.segmentTextWithHighlights(
+      textContent,
+      highlights,
+      pageNumber,
+      scale,
+      viewport
+    );
+    const unifiedLayer = this.buildDOM(segments, scale, viewport);
 
     this.positionLayer(unifiedLayer, pageContainer);
 
@@ -63,9 +75,10 @@ export class UnifiedLayerBuilder {
     highlights: InputHighlightData[],
     pageNumber: number,
     textContent: TextContent,
-    scale = 1.5
+    scale = 1.5,
+    viewport?: TextLayerViewport
   ): void {
-    this.buildUnifiedLayer(pageContainer, textContent, highlights, pageNumber, scale);
+    this.buildUnifiedLayer(pageContainer, textContent, highlights, pageNumber, scale, viewport);
   }
 
   private buildPageHighlights(
@@ -93,13 +106,17 @@ export class UnifiedLayerBuilder {
   private segmentTextWithHighlights(
     textContent: TextContent,
     highlights: InputHighlightData[],
-    pageNumber: number
+    pageNumber: number,
+    scale: number,
+    viewport?: TextLayerViewport
   ): Segment[] {
     const segments: Segment[] = [];
     const pageHighlights = this.buildPageHighlights(highlights, pageNumber);
 
     textContent.items.forEach((textItem) => {
-      const itemBounds = this.getTextItemBounds(textItem);
+      const itemBounds = viewport
+        ? this.getTextItemBoundsDisplayNormalized(textItem, viewport, scale)
+        : this.getTextItemBounds(textItem);
       const itemHighlights = this.getHighlightsForTextItem(itemBounds, pageHighlights);
 
       if (itemHighlights.length === 0) {
@@ -111,7 +128,11 @@ export class UnifiedLayerBuilder {
           fontName: textItem.fontName,
         });
       } else {
-        const highlightedSegments = this.createHighlightedSegments(textItem, itemHighlights);
+        const highlightedSegments = this.createHighlightedSegments(
+          textItem,
+          itemHighlights,
+          itemBounds
+        );
         segments.push(...highlightedSegments);
       }
     });
@@ -132,10 +153,10 @@ export class UnifiedLayerBuilder {
 
   private createHighlightedSegments(
     textItem: TextItem,
-    itemHighlights: ItemHighlight[]
+    itemHighlights: ItemHighlight[],
+    itemBounds: BoundingBox
   ): Segment[] {
     const segments: Segment[] = [];
-    const itemBounds = this.getTextItemBounds(textItem);
 
     const primary = itemHighlights[0];
 
@@ -205,30 +226,38 @@ export class UnifiedLayerBuilder {
     };
   }
 
-  private buildDOM(segments: Segment[], scale: number): HTMLElement {
+  private buildDOM(segments: Segment[], scale: number, viewport?: TextLayerViewport): HTMLElement {
     const unifiedLayer = document.createElement('div');
     unifiedLayer.className = 'unified-layer';
 
     segments.forEach((segment) => {
       const el = segment.hasHighlight
-        ? this.createHighlightElement(segment, scale)
-        : this.createTextElement(segment, scale);
+        ? this.createHighlightElement(segment, scale, viewport)
+        : this.createTextElement(segment, scale, viewport);
       unifiedLayer.appendChild(el);
     });
 
     return unifiedLayer;
   }
 
-  private createTextElement(segment: Segment, scale: number): HTMLElement {
+  private createTextElement(
+    segment: Segment,
+    scale: number,
+    viewport?: TextLayerViewport
+  ): HTMLElement {
     const span = document.createElement('span');
     span.className = 'text-segment selectable';
     span.textContent = segment.text;
 
-    this.applyTextPositioning(span, segment, scale);
+    this.applyTextPositioning(span, segment, scale, viewport);
     return span;
   }
 
-  private createHighlightElement(segment: Segment, scale: number): HTMLElement {
+  private createHighlightElement(
+    segment: Segment,
+    scale: number,
+    viewport?: TextLayerViewport
+  ): HTMLElement {
     const wrapper = document.createElement('span');
     wrapper.className = 'highlight-wrapper';
     wrapper.setAttribute('data-term-id', segment.highlightInfo?.termId || '');
@@ -284,7 +313,7 @@ export class UnifiedLayerBuilder {
 
     this.applyInlineHighlightStyle(background, segment.highlightInfo?.style);
 
-    this.applyTextPositioning(wrapper, segment, scale);
+    this.applyTextPositioning(wrapper, segment, scale, viewport);
     wrapper.style.position = 'absolute';
     wrapper.style.userSelect = 'text';
 
@@ -325,19 +354,64 @@ export class UnifiedLayerBuilder {
     };
   }
 
+  /** Bounds in the same normalized display space as rotated highlight bboxes (divide viewport px by scale). */
+  private getTextItemBoundsDisplayNormalized(
+    item: TextItem,
+    viewport: TextLayerViewport,
+    scale: number
+  ): BoundingBox {
+    const x = item.transform[4];
+    const y = item.transform[5];
+    const w = (item.width ?? 0) as number;
+    const h = (item.height ?? 0) as number;
+    const corners: [number, number][] = [
+      [x, y - h],
+      [x + w, y - h],
+      [x + w, y],
+      [x, y],
+    ];
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    const s = scale > 0 ? scale : 1;
+    for (const [cx, cy] of corners) {
+      const p = viewport.convertToViewportPoint(cx, cy);
+      const px = p[0] ?? 0;
+      const py = p[1] ?? 0;
+      minX = Math.min(minX, px / s);
+      minY = Math.min(minY, py / s);
+      maxX = Math.max(maxX, px / s);
+      maxY = Math.max(maxY, py / s);
+    }
+    return { x1: minX, y1: minY, x2: maxX, y2: maxY };
+  }
+
   private boundsIntersect(a: BoundingBox, b: BoundingBox): boolean {
     return !(a.x2 < b.x1 || a.x1 > b.x2 || a.y2 < b.y1 || a.y1 > b.y2);
   }
 
-  private applyTextPositioning(element: HTMLElement, segment: Segment, scale: number): void {
+  private applyTextPositioning(
+    element: HTMLElement,
+    segment: Segment,
+    scale: number,
+    viewport?: TextLayerViewport
+  ): void {
     const transform = segment.transform;
-    const x = transform[4] * scale;
-    const y = transform[5] * scale;
     const scaleX = transform[0] * scale;
     const scaleY = transform[3] * scale;
 
-    element.style.left = `${x}px`;
-    element.style.top = `${y}px`;
+    if (viewport) {
+      const p = viewport.convertToViewportPoint(transform[4], transform[5]);
+      element.style.left = `${p[0] ?? 0}px`;
+      element.style.top = `${p[1] ?? 0}px`;
+    } else {
+      const x = transform[4] * scale;
+      const y = transform[5] * scale;
+      element.style.left = `${x}px`;
+      element.style.top = `${y}px`;
+    }
+
     element.style.transform = `scale(${scaleX}, ${scaleY})`;
     element.style.transformOrigin = '0% 0%';
     element.style.whiteSpace = 'pre';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { PDFHighlightViewer } from './PDFHighlightViewer';
 
 export { PDFHighlightViewer } from './PDFHighlightViewer';
-export { ZoomMode } from './types';
+export { RotationDirection, ZoomMode } from './types';
 
 export type { PDFHighlightViewer as IPDFHighlightViewer } from './api';
 
@@ -25,6 +25,8 @@ export type {
   LoadPDFOptions,
   MemoryMetrics,
   Page,
+  PageDisplayRotationClockwise,
+  PageRotationDegrees,
   PageChangeEvent,
   PDFSource,
   PerformanceMetrics,
@@ -60,8 +62,20 @@ export {
 } from './core/performance-optimizer';
 export { TextSegmentation } from './core/text-segmentation';
 export { UnifiedLayerBuilder } from './core/unified-layer-builder';
+export type { TextLayerViewport } from './core/unified-layer-builder';
 export { ViewportManager } from './core/viewport-manager';
 
+export {
+  clockwiseToCcw,
+  displayRotationToClockwise,
+  rotateBoundingBoxForCcwRotation,
+  rotatePointCcw,
+} from './utils/rotate-bbox';
+export {
+  normalizePdfRotationDegrees,
+  PDF_ROTATION_FULL_CIRCLE_DEGREES,
+  sumPdfIntrinsicAndUserRotation,
+} from './utils/pdf-rotation-math';
 export {
   b64toArrayBuffer,
   b64toBlob,

--- a/src/types.ts
+++ b/src/types.ts
@@ -283,6 +283,8 @@ export interface Page {
   loading: boolean;
   viewport?: unknown;
   scale?: number;
+  /** PDF.js viewport rotation (clockwise degrees) used for the cached canvas, if rendered. */
+  viewportRotation?: number;
 }
 
 export interface HighlightsConfig {
@@ -291,6 +293,21 @@ export interface HighlightsConfig {
 }
 
 export type BBoxOrigin = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+
+/** Quadrant rotations in degrees (0, 90, 180, 270). Used for display delta and bbox math. */
+export type PageRotationDegrees = 0 | 90 | 180 | 270;
+
+/**
+ * @deprecated Use {@link PageRotationDegrees}. Kept for backward compatibility; same union.
+ */
+export type PageDisplayRotationClockwise = PageRotationDegrees;
+
+/** User rotation sense: clockwise or counter-clockwise (see `displayRotationToClockwise` in rotate-bbox). */
+export enum RotationDirection {
+  Clockwise = 'cw',
+  CounterClockwise = 'ccw',
+}
+
 export type PDFSource = string | ArrayBuffer | Blob;
 
 /** Options passed when loading a PDF (e.g. to override selected pages per load). */
@@ -312,6 +329,10 @@ export interface ViewerOptions {
   bboxSourceDimensions?: BBoxDimensions;
   /** Only show these document page numbers (1-based). If empty or omitted, all pages are shown. */
   selectedPages?: number[];
+  /**
+   * Initial extra clockwise rotation per 1-based page (0, 90, 180, 270), on top of the PDF intrinsic rotation.
+   */
+  pageDisplayRotations?: Record<number, PageRotationDegrees>;
 }
 
 export interface ThumbnailOptions {
@@ -321,6 +342,11 @@ export interface ThumbnailOptions {
   format?: 'image/jpeg' | 'image/webp' | 'image/png';
   /** Quality for jpeg/webp (0–1). Used by getThumbnailsDataUrl. Default 0.85. */
   quality?: number;
+  /**
+   * Per 1-based page: total PDF.js viewport rotation in degrees (clockwise).
+   * When omitted for a page, the PDF default rotation is used.
+   */
+  viewportRotations?: Record<number, number>;
 }
 
 export interface AccessibilityFeatures {

--- a/src/utils/__tests__/pdf-rotation-math.test.ts
+++ b/src/utils/__tests__/pdf-rotation-math.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'vitest';
+import { normalizePdfRotationDegrees, sumPdfIntrinsicAndUserRotation } from '../pdf-rotation-math';
+
+describe('normalizePdfRotationDegrees', () => {
+  test('wraps to [0, 360)', () => {
+    expect(normalizePdfRotationDegrees(450)).toBe(90);
+    expect(normalizePdfRotationDegrees(-90)).toBe(270);
+    expect(normalizePdfRotationDegrees(0)).toBe(0);
+  });
+});
+
+describe('sumPdfIntrinsicAndUserRotation', () => {
+  test('combines and normalizes', () => {
+    expect(sumPdfIntrinsicAndUserRotation(90, 90)).toBe(180);
+    expect(sumPdfIntrinsicAndUserRotation(270, 180)).toBe(90);
+  });
+});

--- a/src/utils/__tests__/rotate-bbox.test.ts
+++ b/src/utils/__tests__/rotate-bbox.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'vitest';
+import { RotationDirection } from '../../types';
+import {
+  clockwiseToCcw,
+  displayRotationToClockwise,
+  rotateBoundingBoxForCcwRotation,
+} from '../rotate-bbox';
+
+describe('displayRotationToClockwise', () => {
+  test('cw preserves degrees', () => {
+    expect(displayRotationToClockwise(90, RotationDirection.Clockwise)).toBe(90);
+    expect(displayRotationToClockwise(180, RotationDirection.Clockwise)).toBe(180);
+    expect(displayRotationToClockwise(270, RotationDirection.Clockwise)).toBe(270);
+  });
+
+  test('ccw maps to complementary clockwise', () => {
+    expect(displayRotationToClockwise(90, RotationDirection.CounterClockwise)).toBe(270);
+    expect(displayRotationToClockwise(270, RotationDirection.CounterClockwise)).toBe(90);
+    expect(displayRotationToClockwise(180, RotationDirection.CounterClockwise)).toBe(180);
+  });
+
+  test('0 ignores direction', () => {
+    expect(displayRotationToClockwise(0, RotationDirection.Clockwise)).toBe(0);
+    expect(displayRotationToClockwise(0, RotationDirection.CounterClockwise)).toBe(0);
+  });
+});
+
+describe('clockwiseToCcw', () => {
+  test('maps clockwise delta to CCW', () => {
+    expect(clockwiseToCcw(90)).toBe(270);
+    expect(clockwiseToCcw(270)).toBe(90);
+    expect(clockwiseToCcw(180)).toBe(180);
+    expect(clockwiseToCcw(0)).toBe(0);
+  });
+});
+
+describe('rotateBoundingBoxForCcwRotation', () => {
+  test('returns copy for 0°', () => {
+    const b = { x1: 1, y1: 2, x2: 5, y2: 8 };
+    const out = rotateBoundingBoxForCcwRotation(b, 100, 200, 0);
+    expect(out).toEqual(b);
+    expect(out).not.toBe(b);
+  });
+
+  test('rotates zero-width segment to horizontal', () => {
+    const b = { x1: 10, y1: 10, x2: 10, y2: 20 };
+    const out = rotateBoundingBoxForCcwRotation(b, 100, 200, 90);
+    expect(out.y1).toBeCloseTo(out.y2);
+    expect(out.x1).toBeCloseTo(10);
+    expect(out.x2).toBeCloseTo(20);
+    expect(out.y1).toBeCloseTo(90);
+  });
+
+  test('90° CCW on non-square page swaps extent', () => {
+    const origW = 200;
+    const origH = 100;
+    const b = { x1: 0, y1: 0, x2: 50, y2: 40 };
+    const out = rotateBoundingBoxForCcwRotation(b, origW, origH, 90);
+    expect(out.x1).toBe(0);
+    expect(out.y1).toBeCloseTo(150);
+    expect(out.x2).toBe(40);
+    expect(out.y2).toBeCloseTo(200);
+  });
+
+  test('90° CW equals 270° CCW', () => {
+    const origW = 120;
+    const origH = 80;
+    const b = { x1: 10, y1: 20, x2: 60, y2: 50 };
+    const cw90 = rotateBoundingBoxForCcwRotation(b, origW, origH, clockwiseToCcw(90));
+    const ccw270 = rotateBoundingBoxForCcwRotation(b, origW, origH, 270);
+    expect(cw90).toEqual(ccw270);
+  });
+
+  test('180° flips around both axes', () => {
+    const w = 100;
+    const h = 80;
+    const b = { x1: 10, y1: 20, x2: 40, y2: 50 };
+    const out = rotateBoundingBoxForCcwRotation(b, w, h, 180);
+    expect(out).toEqual({ x1: 60, y1: 30, x2: 90, y2: 60 });
+  });
+});

--- a/src/utils/pdf-rotation-math.ts
+++ b/src/utils/pdf-rotation-math.ts
@@ -1,0 +1,20 @@
+/** Full circle in degrees (PDF.js / CSS rotation convention). */
+export const PDF_ROTATION_FULL_CIRCLE_DEGREES = 360 as const;
+
+/**
+ * Normalize any signed rotation to [0, 360).
+ */
+export function normalizePdfRotationDegrees(degrees: number): number {
+  const full = PDF_ROTATION_FULL_CIRCLE_DEGREES;
+  return ((degrees % full) + full) % full;
+}
+
+/**
+ * Combine PDF page intrinsic `/Rotate` (clockwise, degrees) with extra user clockwise delta.
+ */
+export function sumPdfIntrinsicAndUserRotation(
+  intrinsicRotateDegrees: number,
+  userClockwiseDegrees: number
+): number {
+  return normalizePdfRotationDegrees(intrinsicRotateDegrees + userClockwiseDegrees);
+}

--- a/src/utils/rotate-bbox.ts
+++ b/src/utils/rotate-bbox.ts
@@ -1,0 +1,127 @@
+import type { BoundingBox, PageRotationDegrees } from '../types';
+import { RotationDirection } from '../types';
+import { normalizePdfRotationDegrees, PDF_ROTATION_FULL_CIRCLE_DEGREES } from './pdf-rotation-math';
+
+/**
+ * PDF.js applies viewport rotation clockwise. User display delta is clockwise;
+ * this helper converts to CCW for `rotateBoundingBoxForCcwRotation`.
+ */
+export function clockwiseToCcw(clockwise: PageRotationDegrees): PageRotationDegrees {
+  return normalizePdfRotationDegrees(
+    PDF_ROTATION_FULL_CIRCLE_DEGREES - clockwise
+  ) as PageRotationDegrees;
+}
+
+/**
+ * Combine quadrant degrees (0|90|180|270) with direction → extra clockwise delta (0|90|180|270).
+ * For `degrees === 0`, returns 0 and ignores `direction`.
+ */
+export function displayRotationToClockwise(
+  degrees: PageRotationDegrees,
+  direction: RotationDirection
+): PageRotationDegrees {
+  if (degrees === 0) {
+    return 0;
+  }
+  if (direction === RotationDirection.Clockwise) {
+    return degrees;
+  }
+  return normalizePdfRotationDegrees(
+    PDF_ROTATION_FULL_CIRCLE_DEGREES - degrees
+  ) as PageRotationDegrees;
+}
+
+/** Rotate a point (intrinsic top-left, y-down) by CCW rotation around the intrinsic top-left corner. */
+export function rotatePointCcw(
+  x: number,
+  y: number,
+  origWidth: number,
+  origHeight: number,
+  rotationCcw: PageRotationDegrees
+): [number, number] {
+  const d = normalizePdfRotationDegrees(rotationCcw);
+  if (d === 0) {
+    return [x, y];
+  }
+  if (d === 90) {
+    return [y, origWidth - x];
+  }
+  if (d === 180) {
+    return [origWidth - x, origHeight - y];
+  }
+  if (d === 270) {
+    return [origHeight - y, x];
+  }
+  throw new Error(`Unsupported rotation: ${rotationCcw}`);
+}
+
+/**
+ * Rotate an axis-aligned bbox (top-left origin, y-down) around the top-left corner
+ * of an origWidth × origHeight intrinsic page into display space.
+ */
+export function rotateBoundingBoxForCcwRotation(
+  bbox: BoundingBox,
+  origWidth: number,
+  origHeight: number,
+  rotationCcw: PageRotationDegrees
+): BoundingBox {
+  if (rotationCcw === 0) {
+    return { ...bbox };
+  }
+
+  let x1 = bbox.x1;
+  let x2 = bbox.x2;
+  let y1 = bbox.y1;
+  let y2 = bbox.y2;
+
+  if (x2 < x1) {
+    [x1, x2] = [x2, x1];
+  }
+  if (y2 < y1) {
+    [y1, y2] = [y2, y1];
+  }
+
+  if (x1 === x2 && y1 === y2) {
+    const [px, py] = rotatePointCcw(x1, y1, origWidth, origHeight, rotationCcw);
+    return { x1: px, y1: py, x2: px, y2: py };
+  }
+
+  if (x1 === x2 || y1 === y2) {
+    const [ax, ay] = rotatePointCcw(x1, y1, origWidth, origHeight, rotationCcw);
+    const [bx, by] = rotatePointCcw(x2, y2, origWidth, origHeight, rotationCcw);
+    return {
+      x1: Math.min(ax, bx),
+      y1: Math.min(ay, by),
+      x2: Math.max(ax, bx),
+      y2: Math.max(ay, by),
+    };
+  }
+
+  const corners: [number, number][] = [
+    [x1, y1],
+    [x2, y1],
+    [x2, y2],
+    [x1, y2],
+  ];
+
+  const d = normalizePdfRotationDegrees(rotationCcw);
+  let transformed: [number, number][];
+  if (d === 90) {
+    transformed = corners.map(([x, y]) => [y, origWidth - x]);
+  } else if (d === 180) {
+    transformed = corners.map(([x, y]) => [origWidth - x, origHeight - y]);
+  } else if (d === 270) {
+    transformed = corners.map(([x, y]) => [origHeight - y, x]);
+  } else {
+    throw new Error(`Unsupported rotation: ${rotationCcw}`);
+  }
+
+  const xs = transformed.map((p) => p[0]);
+  const ys = transformed.map((p) => p[1]);
+  return {
+    x1: Math.min(...xs),
+    y1: Math.min(...ys),
+    x2: Math.max(...xs),
+    y2: Math.max(...ys),
+  };
+}


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->

- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Per-page display rotation (CW/CCW + 0/90/180/270), integrated with PDF.js viewport, highlights, text layer, zoom/fit, and thumbnails.
API: setPageDisplayRotation / getPageDisplayRotation, optional init map, pageRotationChanged event.
Helpers: rotate-bbox + pdf-rotation-math; shared types PageRotationDegrees and RotationDirection enum.
Example: toolbar controls to try rotation; shared select styles.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
