### PR TITLE
fix: kill RAF and Interval when viewer is destroyed

### DIFF
--- a/src/core/performance-optimizer.ts
+++ b/src/core/performance-optimizer.ts
@@ -587,7 +587,6 @@ export class PerformanceOptimizer {
 
       if (currentTime - lastTime >= 1000) {
         this.performanceMetrics.fps = frameCount;
-        console.log('[PerformanceOptimizer] FPS:', frameCount, 'memory:', this.memoryManager.getMemoryUsage());
         frameCount = 0;
         lastTime = currentTime;
       }

--- a/src/core/performance-optimizer.ts
+++ b/src/core/performance-optimizer.ts
@@ -241,6 +241,7 @@ export class MemoryManager {
   private cache = new Map<string, { data: unknown; lastAccess: number; size: number }>();
   private maxCacheSize: number;
   private currentCacheSize = 0;
+  private monitoringIntervalId: ReturnType<typeof setInterval> | null = null;
 
   constructor(maxCacheSizeMB = 100) {
     this.maxCacheSize = maxCacheSizeMB * 1024 * 1024;
@@ -289,6 +290,14 @@ export class MemoryManager {
   clear(): void {
     this.cache.clear();
     this.currentCacheSize = 0;
+  }
+
+  destroy(): void {
+    if (this.monitoringIntervalId !== null) {
+      clearInterval(this.monitoringIntervalId);
+      this.monitoringIntervalId = null;
+    }
+    this.clear();
   }
 
   getMemoryUsage(): MemoryMetrics {
@@ -369,7 +378,7 @@ export class MemoryManager {
   }
 
   private startMemoryMonitoring(): void {
-    setInterval(() => {
+    this.monitoringIntervalId = setInterval(() => {
       const usage = this.getMemoryUsage();
       if (usage.total && usage.total > 200) {
         console.warn('High memory usage detected:', usage);
@@ -514,6 +523,8 @@ export class PerformanceOptimizer {
   public renderOptimizer: RenderOptimizer;
   public workerManager: WorkerTaskManager | null = null;
 
+  private rafId: number | null = null;
+
   private performanceMetrics: PerformanceMetrics = {
     renderTime: 0,
     highlightRenderTime: 0,
@@ -576,14 +587,15 @@ export class PerformanceOptimizer {
 
       if (currentTime - lastTime >= 1000) {
         this.performanceMetrics.fps = frameCount;
+        console.log('[PerformanceOptimizer] FPS:', frameCount, 'memory:', this.memoryManager.getMemoryUsage());
         frameCount = 0;
         lastTime = currentTime;
       }
 
-      requestAnimationFrame(monitorFPS);
+      this.rafId = requestAnimationFrame(monitorFPS);
     };
 
-    monitorFPS();
+    this.rafId = requestAnimationFrame(monitorFPS);
   }
 
   optimize(): void {
@@ -601,7 +613,12 @@ export class PerformanceOptimizer {
   }
 
   destroy(): void {
-    this.memoryManager.clear();
+    if (this.rafId !== null) {
+      cancelAnimationFrame(this.rafId);
+      this.rafId = null;
+    }
+
+    this.memoryManager.destroy();
     this.spatialIndex.clear();
     this.renderOptimizer.clearQueue();
 


### PR DESCRIPTION
### Applicable issues

- Issue https://github.com/epam/pdf-highlighter-kit/issues/43

### Description of changes

Kill RAF and Interval when destroy `PerformanceOptimizer`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
